### PR TITLE
Fix allowlist enforcement for file and network tools

### DIFF
--- a/SECURITY_AUDIT_FIXES.md
+++ b/SECURITY_AUDIT_FIXES.md
@@ -7,9 +7,15 @@
 
 ## AUDIT FINDINGS & FIXES
 
+### 🔴 CRITICAL #7: Allowlist Enforcement Bypassed (Feb 2025 follow-up)
+**Finding**: `file_operations`, `ping_host`, `test_port_connectivity`, and `http_request_test` compared the tuple returned by `filesec.is_path_allowed()` / `netsec.*` directly in boolean expressions.
+**Impact**: Python treats non-empty tuples as truthy, so the "deny" branch never executed. Attackers could read any file (including `/etc/shadow` and SSH keys) and issue arbitrary network probes/HTTP requests despite the newly added security helpers.
+**Fix**: ✅ Updated `src/mcp_server.py` to unpack `(allowed, reason)` tuples and enforce the boolean flag before performing any file or network operations. Added defensive error messaging so the caller knows why access was denied.
+**Tests**: ✅ Added `tests/test_security_enforcement.py` to ensure every tool aborts before touching the system when the helpers report "blocked".
+
 ### 🔴 CRITICAL #1: Security Middleware Never Wired
-**Finding**: Security middleware exists but `@secure_tool()` decorator never applied to any MCP tools  
-**Impact**: All endpoints completely unauthenticated  
+**Finding**: Security middleware exists but `@secure_tool()` decorator never applied to any MCP tools
+**Impact**: All endpoints completely unauthenticated
 **Fix**: ✅ Added `@secure_tool()` decorator to all 23 MCP tools  
 **Files**: `src/mcp_server.py`  
 **Note**: FastMCP doesn't support `**kwargs` in tools - will need to refactor to use Context state instead in production

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -234,10 +234,11 @@ async def file_operations(
     try:
         # SECURITY: Validate and sanitize path
         clean_path = filesec.sanitize_path(path)
-        if not filesec.is_path_allowed(clean_path):
+        path_allowed, reason = filesec.is_path_allowed(clean_path)
+        if not path_allowed:
             return {
                 "success": False,
-                "error": f"Access denied: {path} is not in allowed paths or matches deny pattern",
+                "error": f"Access denied: {reason}",
                 "allowed_paths": filesec.DEFAULT_ALLOWED_PATHS
             }
         
@@ -425,10 +426,12 @@ async def ping_host(host: str, count: int = 4, format: Literal["json", "toon"] =
     
     try:
         # SECURITY: Validate host to prevent SSRF
-        if not netsec.is_host_allowed(host):
+        host_allowed, reason = netsec.is_host_allowed(host)
+        if not host_allowed:
             return format_response({
                 "success": False,
-                "error": f"Access denied: {host} is not allowed (private IP or metadata service blocked)"
+                "error": f"Access denied: {reason}",
+                "host": host
             }, format)
         
         # Linux/Unix ping command
@@ -483,25 +486,35 @@ async def test_port_connectivity(host: str, port: int = None, ports: list[int] =
     
     try:
         # SECURITY: Validate host and ports
-        if not netsec.is_host_allowed(host):
+        host_allowed, host_reason = netsec.is_host_allowed(host)
+        if not host_allowed:
             return {
                 "success": False,
-                "error": f"Access denied: {host} is not allowed (private IP or metadata service blocked)"
+                "error": f"Access denied: {host_reason}",
             }
         
         # Determine which ports to test
         test_ports = []
         if port:
-            if not netsec.is_port_allowed(port):
-                return {"success": False, "error": f"Port {port} is not allowed"}
+            port_allowed, reason = netsec.is_port_allowed(port)
+            if not port_allowed:
+                return {"success": False, "error": f"Port {port} is not allowed: {reason}"}
             test_ports = [port]
         elif ports:
-            test_ports = [p for p in ports if netsec.is_port_allowed(p)]
+            filtered_ports = []
+            for p in ports:
+                allowed, _reason = netsec.is_port_allowed(p)
+                if allowed:
+                    filtered_ports.append(p)
+            test_ports = filtered_ports
             if not test_ports:
                 return {"success": False, "error": "No allowed ports in request"}
         else:
-            # Default common ports for localhost
-            test_ports = [22, 80, 443, 3306, 5432, 6379, 8080]
+            # Default common ports for localhost (filtered through allowlist)
+            default_ports = [22, 80, 443, 3306, 5432, 6379, 8080]
+            test_ports = [p for p in default_ports if netsec.is_port_allowed(p)[0]]
+            if not test_ports:
+                return {"success": False, "error": "No default ports are permitted by the allowlist"}
         
         results = []
         open_count = 0
@@ -634,10 +647,12 @@ async def http_request_test(url: str, method: str = "GET", timeout: int = 10) ->
     
     try:
         # SECURITY: Validate URL to prevent SSRF
-        if not netsec.is_url_allowed(url):
+        url_allowed, reason = netsec.is_url_allowed(url)
+        if not url_allowed:
             return {
                 "success": False,
-                "error": f"Access denied: {url} targets private IP or metadata service"
+                "error": f"Access denied: {reason}",
+                "url": url,
             }
         
         import requests

--- a/tests/test_security_enforcement.py
+++ b/tests/test_security_enforcement.py
@@ -1,0 +1,99 @@
+import pytest
+
+from src import mcp_server
+
+
+@pytest.mark.asyncio
+async def test_file_operations_respects_allowlist(monkeypatch):
+    """file_operations should deny access when filesec rejects a path."""
+
+    def fake_is_path_allowed(path):
+        return False, "path blocked"
+
+    monkeypatch.setattr("utils.filesec.is_path_allowed", fake_is_path_allowed)
+
+    result = await mcp_server.file_operations.fn.__wrapped__(
+        action="list",
+        path="/tmp",
+        lines=10,
+        offset=0,
+        pattern="*",
+    )
+
+    assert result["success"] is False
+    assert "path blocked" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_ping_host_rejects_blocked_host(monkeypatch):
+    """ping_host must refuse disallowed hosts before spawning ping."""
+
+    def fake_is_host_allowed(host):
+        return False, "host blocked"
+
+    def fail_run(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("ping should not execute for blocked hosts")
+
+    monkeypatch.setattr("utils.netsec.is_host_allowed", fake_is_host_allowed)
+    monkeypatch.setattr("subprocess.run", fail_run)
+
+    result = await mcp_server.ping_host.fn.__wrapped__(
+        host="10.0.0.1",
+        count=1,
+        format="json",
+    )
+
+    assert result["success"] is False
+    assert "host blocked" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_test_port_connectivity_rejects_blocked_port(monkeypatch):
+    """test_port_connectivity should stop when a port is not allowlisted."""
+
+    def fake_is_host_allowed(host):
+        return True, "host ok"
+
+    def fake_is_port_allowed(port):
+        return False, "port blocked"
+
+    class FailSocket:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - should not run
+            raise AssertionError("socket should not be created for blocked ports")
+
+    monkeypatch.setattr("utils.netsec.is_host_allowed", fake_is_host_allowed)
+    monkeypatch.setattr("utils.netsec.is_port_allowed", fake_is_port_allowed)
+    monkeypatch.setattr("socket.socket", FailSocket)
+
+    result = await mcp_server.test_port_connectivity.fn.__wrapped__(
+        host="example.com",
+        port=1234,
+        ports=None,
+        timeout=1,
+    )
+
+    assert result["success"] is False
+    assert "port blocked" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_http_request_test_rejects_blocked_url(monkeypatch):
+    """http_request_test must deny blocked URLs before issuing requests."""
+
+    def fake_is_url_allowed(url):
+        return False, "url blocked"
+
+    def fail_request(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("HTTP request should not run for blocked URLs")
+
+    monkeypatch.setattr("utils.netsec.is_url_allowed", fake_is_url_allowed)
+    monkeypatch.setattr("requests.request", fail_request)
+
+    result = await mcp_server.http_request_test.fn.__wrapped__(
+        url="http://169.254.169.254/latest/meta-data/",
+        method="GET",
+        timeout=5,
+    )
+
+    assert result["success"] is False
+    assert "url blocked" in result["error"]


### PR DESCRIPTION
## Summary
- fix `file_operations`, `ping_host`, `test_port_connectivity`, and `http_request_test` so the allowlist helpers can actually block disallowed paths, hosts, ports, and URLs
- add regression tests that prove these MCP tools short-circuit before touching the system when a helper reports "blocked"
- document the newly discovered tuple-truthiness bug in `SECURITY_AUDIT_FIXES.md`

## Testing
- `PYTHONPATH=src:. pytest tests/test_security_enforcement.py tests/test_security.py tests/test_security_audit_fixes.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919319b0000832f90b1084a8171a40e)