### PR TITLE
Add TSIDP login controller and GoFast auth service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Core SystemManager authentication settings
+SYSTEMMANAGER_AUTH_MODE=token
+SYSTEMMANAGER_REQUIRE_AUTH=true
+SYSTEMMANAGER_ENABLE_APPROVAL=false
+SYSTEMMANAGER_SHARED_SECRET=change-me
+SYSTEMMANAGER_JWT_SECRET=
+
+# TSIDP (Tailscale Identity Provider) OAuth configuration
+TSIDP_URL=https://tsidp.tailf9480.ts.net
+TSIDP_CLIENT_ID=systemmanager-dev
+TSIDP_CLIENT_SECRET=
+TSIDP_REDIRECT_URI=http://localhost:8900/callback
+TSIDP_SCOPES="openid profile email"
+
+# GoFast MCP authentication bridge
+SYSTEMMANAGER_MCP_AUTH_URL=https://gofastmcp.com/servers/auth/authentication
+MCP_AUTH_CLIENT_ID=
+MCP_AUTH_CLIENT_SECRET=
+
+# Optional base URL used when FastMCP advertises HTTP endpoints
+SYSTEMMANAGER_BASE_URL=http://localhost:8080

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,4 @@
+"""Authentication helpers for SystemManager."""
+
+from .mcp_auth_service import GoFastMCPAuthService, MCPTokenSession  # noqa: F401
+from .tsidp_login import TSIDPLoginController  # noqa: F401

--- a/src/auth/mcp_auth_service.py
+++ b/src/auth/mcp_auth_service.py
@@ -1,0 +1,181 @@
+"""Utilities for exchanging TSIDP tokens with the GoFast MCP auth server."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_AUTH_URL = "https://gofastmcp.com/servers/auth/authentication"
+
+
+@dataclass
+class MCPTokenSession:
+    """Represents an MCP token issued by the GoFast auth server."""
+
+    access_token: str
+    expires_at: datetime
+    refresh_token: Optional[str] = None
+    token_type: str = "Bearer"
+    scope: Optional[str] = None
+    issued_at: datetime = field(default_factory=datetime.utcnow)
+    raw_response: Dict[str, Any] = field(default_factory=dict)
+
+    def is_expired(self, skew_seconds: int = 30) -> bool:
+        """Return True if the token is expired or about to expire."""
+
+        return datetime.utcnow() >= (self.expires_at - timedelta(seconds=skew_seconds))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the session for storage/logging."""
+
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "token_type": self.token_type,
+            "scope": self.scope,
+            "expires_at": self.expires_at.isoformat(),
+            "issued_at": self.issued_at.isoformat(),
+            "raw_response": self.raw_response,
+        }
+
+
+class GoFastMCPAuthService:
+    """Client for exchanging credentials with the GoFast MCP auth server."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        session_store: Optional[Dict[str, MCPTokenSession]] = None,
+        http_session: Optional[requests.Session] = None,
+    ) -> None:
+        self.base_url = base_url or os.getenv("SYSTEMMANAGER_MCP_AUTH_URL", DEFAULT_AUTH_URL)
+        self.client_id = client_id or os.getenv("MCP_AUTH_CLIENT_ID")
+        self.client_secret = client_secret or os.getenv("MCP_AUTH_CLIENT_SECRET")
+        self._session_store: Dict[str, MCPTokenSession] = session_store or {}
+        self._http = http_session or requests.Session()
+
+        if not self.base_url:
+            raise ValueError("SYSTEMMANAGER_MCP_AUTH_URL must be configured")
+
+    def _post_json(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Send a POST request to the GoFast auth server."""
+
+        headers = {"Content-Type": "application/json"}
+        logger.debug("Sending payload to GoFast auth server", extra={"payload_keys": list(payload.keys())})
+        response = self._http.post(self.base_url, json=payload, timeout=30, headers=headers)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:  # pragma: no cover - network failures in CI
+            logger.error("GoFast auth server returned error", extra={"status": response.status_code, "body": response.text})
+            raise RuntimeError(f"GoFast MCP auth request failed: {exc}") from exc
+
+        return response.json()
+
+    def _persist_session(self, session_id: str, token_payload: Dict[str, Any]) -> MCPTokenSession:
+        expires_in = token_payload.get("expires_in", 3600)
+        expires_at = datetime.utcnow() + timedelta(seconds=int(expires_in))
+        session = MCPTokenSession(
+            access_token=token_payload["access_token"],
+            refresh_token=token_payload.get("refresh_token"),
+            token_type=token_payload.get("token_type", "Bearer"),
+            scope=token_payload.get("scope"),
+            expires_at=expires_at,
+            raw_response=token_payload,
+        )
+        self._session_store[session_id] = session
+        logger.info("Stored MCP token session", extra={"session_id": session_id, "expires_at": expires_at.isoformat()})
+        return session
+
+    def exchange_tsidp_token(
+        self,
+        *,
+        id_token: str,
+        access_token: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+        session_id: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> MCPTokenSession:
+        """Exchange TSIDP-issued tokens for a GoFast MCP token."""
+
+        if not id_token:
+            raise ValueError("id_token is required to exchange with GoFast MCP")
+
+        payload: Dict[str, Any] = {
+            "grant_type": "tsidp_token",
+            "tsidp_id_token": id_token,
+        }
+        if access_token:
+            payload["tsidp_access_token"] = access_token
+        if refresh_token:
+            payload["tsidp_refresh_token"] = refresh_token
+        if self.client_id:
+            payload["client_id"] = self.client_id
+        if self.client_secret:
+            payload["client_secret"] = self.client_secret
+        if extra:
+            payload.update(extra)
+
+        token_payload = self._post_json(payload)
+        session_key = session_id or token_payload.get("subject") or token_payload.get("sub") or str(int(time.time()))
+        return self._persist_session(session_key, token_payload)
+
+    def login_with_credentials(
+        self,
+        *,
+        username: str,
+        password: str,
+        scope: Optional[str] = None,
+        session_id: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> MCPTokenSession:
+        """Perform a username/password login with the GoFast server."""
+
+        payload: Dict[str, Any] = {
+            "grant_type": "password",
+            "username": username,
+            "password": password,
+        }
+        if scope:
+            payload["scope"] = scope
+        if self.client_id:
+            payload["client_id"] = self.client_id
+        if self.client_secret:
+            payload["client_secret"] = self.client_secret
+        if extra:
+            payload.update(extra)
+
+        token_payload = self._post_json(payload)
+        session_key = session_id or token_payload.get("subject") or username
+        return self._persist_session(session_key, token_payload)
+
+    def get_session(self, session_id: str) -> Optional[MCPTokenSession]:
+        """Return a cached session if it exists and is not expired."""
+
+        session = self._session_store.get(session_id)
+        if not session:
+            return None
+        if session.is_expired():
+            logger.info("MCP session expired; removing", extra={"session_id": session_id})
+            self._session_store.pop(session_id, None)
+            return None
+        return session
+
+    def store_session(self, session_id: str, session: MCPTokenSession) -> None:
+        """Manually persist a session issued elsewhere."""
+
+        self._session_store[session_id] = session
+
+    def clear_sessions(self) -> None:
+        """Remove all cached sessions (e.g., during logout)."""
+
+        self._session_store.clear()

--- a/src/auth/tsidp_login.py
+++ b/src/auth/tsidp_login.py
@@ -1,0 +1,179 @@
+"""TSIDP login flow helpers that integrate with the GoFast MCP auth server."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+import secrets
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+from urllib.parse import urlencode
+
+import requests
+
+from .mcp_auth_service import GoFastMCPAuthService, MCPTokenSession
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PendingLogin:
+    state: str
+    code_verifier: str
+    created_at: datetime
+
+    def is_expired(self, ttl_seconds: int = 600) -> bool:
+        return datetime.utcnow() >= self.created_at + timedelta(seconds=ttl_seconds)
+
+
+class TSIDPLoginController:
+    """Coordinate TSIDP OAuth (PKCE) login with GoFast MCP token exchange."""
+
+    def __init__(
+        self,
+        *,
+        tsidp_url: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        redirect_uri: Optional[str] = None,
+        scopes: Optional[str] = None,
+        auth_service: Optional[GoFastMCPAuthService] = None,
+        http_session: Optional[requests.Session] = None,
+    ) -> None:
+        self.tsidp_url = tsidp_url or os.getenv("TSIDP_URL", "https://tsidp.tailf9480.ts.net")
+        self.client_id = client_id or os.getenv("TSIDP_CLIENT_ID")
+        self.client_secret = client_secret or os.getenv("TSIDP_CLIENT_SECRET")
+        self.redirect_uri = redirect_uri or os.getenv("TSIDP_REDIRECT_URI", "http://localhost:8900/callback")
+        self.scope = scopes or os.getenv("TSIDP_SCOPES", "openid profile email")
+        self.auth_service = auth_service or GoFastMCPAuthService()
+        self._http = http_session or requests.Session()
+        self._metadata: Optional[Dict[str, str]] = None
+        self._pending: Dict[str, PendingLogin] = {}
+        self._lock = threading.Lock()
+
+    def _discover_metadata(self) -> Dict[str, str]:
+        if self._metadata:
+            return self._metadata
+
+        well_known = f"{self.tsidp_url}/.well-known/openid-configuration"
+        logger.info("Fetching TSIDP metadata", extra={"url": well_known})
+        response = self._http.get(well_known, timeout=15)
+        response.raise_for_status()
+        data = response.json()
+        required_keys = {"authorization_endpoint", "token_endpoint"}
+        missing = required_keys - data.keys()
+        if missing:
+            raise RuntimeError(f"TSIDP metadata missing required keys: {missing}")
+        self._metadata = data
+        return data
+
+    @staticmethod
+    def _generate_pkce_pair() -> Dict[str, str]:
+        code_verifier = base64.urlsafe_b64encode(os.urandom(64)).rstrip(b"=").decode("utf-8")
+        challenge = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+        code_challenge = base64.urlsafe_b64encode(challenge).rstrip(b"=").decode("utf-8")
+        return {"code_verifier": code_verifier, "code_challenge": code_challenge}
+
+    def start_login(self, state: Optional[str] = None) -> Dict[str, str]:
+        """Generate the TSIDP authorization URL for interactive login."""
+
+        if not self.client_id:
+            raise RuntimeError("TSIDP_CLIENT_ID is required to start the login flow")
+
+        metadata = self._discover_metadata()
+        state_value = state or secrets.token_urlsafe(24)
+        pkce = self._generate_pkce_pair()
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "state": state_value,
+            "code_challenge": pkce["code_challenge"],
+            "code_challenge_method": "S256",
+        }
+        authorization_url = f"{metadata['authorization_endpoint']}?{urlencode(params)}"
+
+        with self._lock:
+            self._pending[state_value] = PendingLogin(
+                state=state_value,
+                code_verifier=pkce["code_verifier"],
+                created_at=datetime.utcnow(),
+            )
+
+        logger.debug("Prepared TSIDP login", extra={"state": state_value})
+        return {
+            "authorization_url": authorization_url,
+            "state": state_value,
+            "code_verifier": pkce["code_verifier"],
+            "code_challenge": pkce["code_challenge"],
+            "expires_at": (datetime.utcnow() + timedelta(minutes=10)).isoformat(),
+        }
+
+    def _pop_pending(self, state: str) -> PendingLogin:
+        with self._lock:
+            entry = self._pending.pop(state, None)
+        if not entry or entry.is_expired():
+            raise RuntimeError("Login state expired or unknown")
+        return entry
+
+    def _exchange_code(self, code: str, code_verifier: str) -> Dict[str, str]:
+        metadata = self._discover_metadata()
+        payload = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_uri,
+            "code_verifier": code_verifier,
+            "client_id": self.client_id,
+        }
+        if self.client_secret:
+            payload["client_secret"] = self.client_secret
+
+        response = self._http.post(metadata["token_endpoint"], data=payload, timeout=15)
+        response.raise_for_status()
+        return response.json()
+
+    def complete_login(self, *, code: str, state: str) -> Dict[str, Dict[str, str]]:
+        """Finalize the login by exchanging the TSIDP code and calling GoFast MCP."""
+
+        if not code or not state:
+            raise ValueError("code and state are required")
+
+        pending = self._pop_pending(state)
+        tsidp_tokens = self._exchange_code(code, pending.code_verifier)
+        mcp_session = self.auth_service.exchange_tsidp_token(
+            id_token=tsidp_tokens.get("id_token", ""),
+            access_token=tsidp_tokens.get("access_token"),
+            refresh_token=tsidp_tokens.get("refresh_token"),
+            session_id=tsidp_tokens.get("id_token") or state,
+        )
+
+        return {
+            "tsidp": {
+                "access_token": tsidp_tokens.get("access_token"),
+                "refresh_token": tsidp_tokens.get("refresh_token"),
+                "id_token": tsidp_tokens.get("id_token"),
+                "expires_in": tsidp_tokens.get("expires_in"),
+                "token_type": tsidp_tokens.get("token_type"),
+                "scope": tsidp_tokens.get("scope"),
+            },
+            "mcp": mcp_session.to_dict(),
+        }
+
+    def refresh_mcp_session(self, session_id: str) -> Optional[MCPTokenSession]:
+        """Return a cached MCP session if it remains valid."""
+
+        return self.auth_service.get_session(session_id)
+
+    def cleanup_expired_states(self) -> None:
+        """Remove expired pending login states to avoid leaks."""
+
+        with self._lock:
+            stale_states = [key for key, entry in self._pending.items() if entry.is_expired()]
+            for key in stale_states:
+                self._pending.pop(key, None)
+                logger.debug("Removed stale TSIDP login state", extra={"state": key})


### PR DESCRIPTION
## Summary
- add a dedicated GoFast MCP authentication service that exchanges TSIDP tokens for MCP tokens and keeps them in an in-memory session store
- introduce a TSIDP login controller that drives the PKCE authorization flow and hands the resulting tokens to the GoFast service
- document the required configuration for TSIDP and GoFast MCP authentication in a new `.env.example`

## Testing
- python -m compileall src/auth/mcp_auth_service.py src/auth/tsidp_login.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a0a107068832f8f8b55b241136e77)